### PR TITLE
[Feat] zustand를 이용한 shppping right now 페이지 완료

### DIFF
--- a/front_week2-3_hw/kakao_style/src/App.js
+++ b/front_week2-3_hw/kakao_style/src/App.js
@@ -10,7 +10,7 @@ function App() {
   const products = useProductStore((state) => state.products);
   return (
     <Wrapper>
-      <Title onClick={() => navigate("/")}>Pick your Necklace!</Title>
+      <Title onClick={() => navigate("/")}>Shopping Right Now!</Title>
       <CartBtn onClick={() => navigate("/heartlist")}>내가 찜한 리스트</CartBtn>
       <Heart
         onClick={() => navigate("/heartlist")}

--- a/front_week2-3_hw/kakao_style/src/pages/ShoppingMain.js
+++ b/front_week2-3_hw/kakao_style/src/pages/ShoppingMain.js
@@ -1,11 +1,16 @@
-import { React, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import ProductItem from "../components/ProductItem";
+import { useSearchStore } from "../store/store";
 
 const ShoppingMain = () => {
   const [data, setData] = useState([]);
-  const shoppingData = async () => {
+
+  const { query, setQuery } = useSearchStore();
+  const [searchInput, setSearchInput] = useState("");
+
+  const shoppingData = async (searchQuery) => {
     const URL = "/v1/search/shop.json";
     const ClientID = "5tvIZreWtKfjKqWP5Lfe";
     const ClientSecret = "Cux7rbskse";
@@ -13,7 +18,7 @@ const ShoppingMain = () => {
     await axios
       .get(URL, {
         params: {
-          query: "목걸이",
+          query: searchQuery,
           display: 24,
         },
         headers: {
@@ -31,20 +36,60 @@ const ShoppingMain = () => {
   };
 
   useEffect(() => {
-    shoppingData();
-  }, []);
+    if (query) {
+      shoppingData(query);
+    }
+  }, [query]);
+
+  const handleSearch = () => {
+    setQuery(searchInput);
+  };
 
   return (
-    <Container>
-      {data &&
-        data.map((item) => (
-          <ShoppingList key={item.productId}>
-            <ProductItem product={item} />
-          </ShoppingList>
-        ))}
-    </Container>
+    <>
+      <SearchContainer>
+        <SearchInput
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="검색어를 입력하세요"
+        />
+        <SearchButton onClick={handleSearch}>검색</SearchButton>
+      </SearchContainer>
+      <Container>
+        {data &&
+          data.map((item) => (
+            <ShoppingList key={item.productId}>
+              <ProductItem product={item} />
+            </ShoppingList>
+          ))}
+      </Container>
+    </>
   );
 };
+
+const SearchContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+
+const SearchInput = styled.input`
+  padding: 8px;
+  font-size: 16px;
+  width: 300px;
+  margin-right: 10px;
+`;
+
+const SearchButton = styled.button`
+  padding: 8px 16px;
+  font-size: 16px;
+  background-color: rgb(243, 222, 104);
+  color: white;
+  border: none;
+  cursor: pointer;
+`;
 
 export const Container = styled.div`
   display: flex;

--- a/front_week2-3_hw/kakao_style/src/store/store.js
+++ b/front_week2-3_hw/kakao_style/src/store/store.js
@@ -20,4 +20,9 @@ const useProductStore = create(
   }))
 );
 
+export const useSearchStore = create((set) => ({
+  query: "아이폰",
+  setQuery: (state) => set({ query: state }),
+}));
+
 export default useProductStore;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
<zustand를 사용하여 나만의 장바구니 사이트 만들기> (..커밋을 중간중간 계속 한다는 걸 까먹었어요! 다음부터는 꼭 챙기기..✨)

### 1. 네이버 쇼핑 api 빌려오기
- 네이버 어플리케이션을 직접 등록해 검색 api를 끌고 와 사용했다. (상품의 제목, 이미지, 가격, 구매링크 사용)

### 2. zustand를 이용하여 store한 데이터(정보)
- 찜한 상품들의 아이디와 화면을 구성하는 해당 상품의 정보들을 저장하는 배열 요소 추가 함수 (useProductStore의 addProduct)
- 하트를 취소했을 경우 기존 배열에서 해당 상품의 아이디 요소를 제거하는 함수 (useProductStore의 removeProduct)
- 다른 페이지로 이동했다 돌아와도 검색된 결과가 유지되도록 하는 검색어 상태 데이터 (초기 검색어를 "아이폰"으로 설정)
(useSearchStore)

### 3. ShoppingMain.js
- 검색창: 처음 페이지에 들어갔을 때는 초기 설정인 "아이폰"의 결과가 나오며 검색창에 검색어를 입력하면 상태데이터를 변경하는 함수가 실행된다.(store.js 의 useSearchStore 사용)
- api 불러오기: 상태 데이터에 저장된 query로 api를 요청
- ProductItem.jsx component를 만들어 검색 결과가 화면에 나오도록 함.
- 사진을 누르면 구매 링크로 연결된다.
- 사진 상단에 있는 하트를 누르면 데이터가 store.js의 products 배열에 저장되고 페이지 상단에 있는 찜 목록 수가 증가한다. 하트를 취소하면 다시 감소한다. (sotre.js의 products 배열, removeProduct 함수 이용)
- 나의 찜한 리스트 버튼을 눌러 페이지를 이동하면 하트를 누른 product의 정보만 나열된다. (store.js의 products 배열을 이용)



## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


https://github.com/user-attachments/assets/f0c2d271-6f19-4fbe-90ed-30e5bfeb1699



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
<네이버 쇼핑 api 불러오기>
- 참고 링크
[https://velog.io/@cjs0097/%EB%84%A4%EC%9D%B4%EB%B2%84-%EC%87%BC%ED%95%91-%EA%B2%80%EC%83%89-API-%EB%B6%88%EB%9F%AC%EC%98%A4%EA%B8%B0](url)
