### PR TITLE
[Feat] 회원 가입, 개인 정보 수정, 마이페이지 조회, 회원 정보 삭제 api 통신 함수 작성

### DIFF
--- a/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+// 세션 실습 함수
 export const createPost = async (newPost) => {
   const { data } = await axios.post("/api/posts", newPost);
   return data;
@@ -17,5 +18,18 @@ export const getPost = async (postId) => {
 
 export const deletePost = async (postId) => {
   const { data } = await axios.delte(`api/posts/${postId}`);
+  return data;
+};
+
+//과제
+// 회원가입
+export const signUp = async (userinfo) => {
+  const { data } = await axios.post(`api/users/signup`, userinfo);
+  return data;
+};
+
+// 개인 정보 수정
+export const UpdateProfile = async (postId, updatedInfo) => {
+  const { data } = await axios.post(`api/users/profile/${postId}`, updatedInfo);
   return data;
 };

--- a/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
@@ -39,3 +39,9 @@ export const mypageFetch = async (userId) => {
   const { data } = await axios.get(`api/mypage/${userId}`);
   return data;
 };
+
+// 회원 정보 삭제
+export const deleteUser = async (userId) => {
+  const { data } = await axios.delete(`api/users/quit/${userId}`);
+  return data;
+};

--- a/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
@@ -17,7 +17,7 @@ export const getPost = async (postId) => {
 };
 
 export const deletePost = async (postId) => {
-  const { data } = await axios.delte(`api/posts/${postId}`);
+  const { data } = await axios.delete(`api/posts/${postId}`);
   return data;
 };
 
@@ -30,7 +30,7 @@ export const signUp = async (userinfo) => {
 
 // 개인 정보 수정
 export const updateProfile = async (userId, updatedInfo) => {
-  const { data } = await axios.post(`api/users/profile/${userId}`, updatedInfo);
+  const { data } = await axios.put(`api/users/profile/${userId}`, updatedInfo);
   return data;
 };
 

--- a/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
@@ -33,3 +33,9 @@ export const updateProfile = async (userId, updatedInfo) => {
   const { data } = await axios.post(`api/users/profile/${userId}`, updatedInfo);
   return data;
 };
+
+// 마이페이지 조회
+export const mypageFetch = async (userId) => {
+  const { data } = await axios.get(`api/mypage/${userId}`);
+  return data;
+};

--- a/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/axios/index.js
@@ -29,7 +29,7 @@ export const signUp = async (userinfo) => {
 };
 
 // 개인 정보 수정
-export const UpdateProfile = async (postId, updatedInfo) => {
-  const { data } = await axios.post(`api/users/profile/${postId}`, updatedInfo);
+export const updateProfile = async (userId, updatedInfo) => {
+  const { data } = await axios.post(`api/users/profile/${userId}`, updatedInfo);
   return data;
 };

--- a/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
@@ -4,6 +4,7 @@ import { updatePost } from "../axios/index";
 import { getPost } from "../axios/index";
 import { deletePost } from "../axios/index";
 import { signUp } from "../axios/index";
+import { updateProfile } from "../axios/index";
 
 export const useCreatePOst = () => {
   return useMutation({
@@ -40,12 +41,26 @@ export const useDeletePost = () => {
   });
 };
 
+// 회원가입
 export const useSignUp = (username, password) => {
   return useMutation({
     mutationFn: ({ username, password }) => signUp(username, password),
     enabled: !!username && !!password,
     onSuccess: () => {
       alert("환영합니다");
+    },
+  });
+};
+
+// 개인 정보 수정
+export const useUpdateProfile = (userId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, updatedInfo }) => updateProfile(userId, updatedInfo),
+    enabled: !!userId,
+    onSuccess: () => {
+      alert("개인 정보가 수정되었습니다");
+      queryClient.invalidateQueries("myPage");
     },
   });
 };

--- a/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
@@ -5,6 +5,7 @@ import { getPost } from "../axios/index";
 import { deletePost } from "../axios/index";
 import { signUp } from "../axios/index";
 import { updateProfile } from "../axios/index";
+import { mypageFetch } from "../axios/index";
 
 export const useCreatePOst = () => {
   return useMutation({
@@ -62,5 +63,16 @@ export const useUpdateProfile = (userId) => {
       alert("개인 정보가 수정되었습니다");
       queryClient.invalidateQueries("myPage");
     },
+  });
+};
+
+// 마이 페이지 조회
+export const useMypageFetch = (userId) => {
+  return useQuery({
+    queryKey: ["mypage", userId],
+    queryFn: () => mypageFetch(userId),
+    enabled: !!userId,
+    staleTime: 30000,
+    cacheTime: 300000,
   });
 };

--- a/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
@@ -3,6 +3,7 @@ import { createPost } from "../axios/index";
 import { updatePost } from "../axios/index";
 import { getPost } from "../axios/index";
 import { deletePost } from "../axios/index";
+import { signUp } from "../axios/index";
 
 export const useCreatePOst = () => {
   return useMutation({
@@ -35,6 +36,16 @@ export const useDeletePost = () => {
     onSuccess: () => {
       alert("게시글이 삭제되었습니다.");
       queryClient.invalidateQueries("postList");
+    },
+  });
+};
+
+export const useSignUp = (username, password) => {
+  return useMutation({
+    mutationFn: ({ username, password }) => signUp(username, password),
+    enabled: !!username && !!password,
+    onSuccess: () => {
+      alert("환영합니다");
     },
   });
 };

--- a/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
@@ -8,7 +8,7 @@ import { updateProfile } from "../axios/index";
 import { mypageFetch } from "../axios/index";
 import { deleteUser } from "../axios/index";
 
-export const useCreatePOst = () => {
+export const useCreatePost = () => {
   return useMutation({
     mutationFn: ({ title, content }) => createPost(title, content),
   });
@@ -16,8 +16,7 @@ export const useCreatePOst = () => {
 
 export const useUpdatePost = (postId) => {
   return useMutation({
-    mutationFn: ({ postId, title, content }) =>
-      updatePost(postId, title, content),
+    mutationFn: ({ title, content }) => updatePost(postId, title, content),
     enabled: !!postId,
   });
 };
@@ -46,7 +45,7 @@ export const useDeletePost = () => {
 // 회원가입
 export const useSignUp = (username, password) => {
   return useMutation({
-    mutationFn: ({ username, password }) => signUp(username, password),
+    mutationFn: () => signUp(username, password),
     enabled: !!username && !!password,
     onSuccess: () => {
       alert("환영합니다");
@@ -55,13 +54,11 @@ export const useSignUp = (username, password) => {
 };
 
 // 개인 정보 수정
-export const useUpdateProfile = (userId) => {
+export const useUpdateProfile = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ userId, updatedInfo }) => updateProfile(userId, updatedInfo),
-    enabled: !!userId,
     onSuccess: () => {
-      alert("개인 정보가 수정되었습니다");
       queryClient.invalidateQueries({ queryKey: ["mypage"] });
     },
   });
@@ -72,18 +69,16 @@ export const useMypageFetch = (userId) => {
   return useQuery({
     queryKey: ["mypage", userId],
     queryFn: () => mypageFetch(userId),
-    enabled: !!userId,
     staleTime: 30000,
     cacheTime: 300000,
   });
 };
 
 // 회원 정보 삭제
-export const useDeleteUser = (userId) => {
+export const useDeleteUser = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ userId }) => deleteUser(userId),
-    enabled: !!userId,
     cacheTime: 300000,
     onSuccess: () => {
       alert("사용자 정보가 삭제되었습니다");

--- a/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
+++ b/front_week_2-5/tanstack-query/src/apis/blog/queries/index.js
@@ -6,6 +6,7 @@ import { deletePost } from "../axios/index";
 import { signUp } from "../axios/index";
 import { updateProfile } from "../axios/index";
 import { mypageFetch } from "../axios/index";
+import { deleteUser } from "../axios/index";
 
 export const useCreatePOst = () => {
   return useMutation({
@@ -61,7 +62,7 @@ export const useUpdateProfile = (userId) => {
     enabled: !!userId,
     onSuccess: () => {
       alert("개인 정보가 수정되었습니다");
-      queryClient.invalidateQueries("myPage");
+      queryClient.invalidateQueries({ queryKey: ["mypage"] });
     },
   });
 };
@@ -74,5 +75,19 @@ export const useMypageFetch = (userId) => {
     enabled: !!userId,
     staleTime: 30000,
     cacheTime: 300000,
+  });
+};
+
+// 회원 정보 삭제
+export const useDeleteUser = (userId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId }) => deleteUser(userId),
+    enabled: !!userId,
+    cacheTime: 300000,
+    onSuccess: () => {
+      alert("사용자 정보가 삭제되었습니다");
+      queryClient.invalidateQueries({ queryKey: ["mypage"] });
+    },
   });
 };


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 --> closed #37


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
# 과제 < Tanstack Query 정복하기>
1) 회원가입 2) 개인정보 수정 3) 마이페이지 조회 4) 회원 삭제의 api 통신 함수를 React Query로 작성해 오기

## 1. 회원가입 (sign-up)
### 요구사항
- 사용자가 입력한 username, password를 받아 서버에 POST 요청하기
- 두 필드가 모두 입력되었을 때 동작하도록 enabled 속성 사용하기
- onSuccess로 알림 띄우기

### Solution
- post 이므로 useMutation 사용!
**useMutation:** 서버에 데이터를 보내거나 변경 사항을 적용할 때 사용하는 hook이다. mutationFn 안에 promise 처리가 이루어지는 함수를 작성한다. onSuccess, onError 등의 옵션을 통해 api 통신 상태에 따른 처리를 효율적으로 할 수 있다.
- enabled: !! username && !!password 코드를 통해 입력 값이 모두 들어 온 경우를 판단
- onSuccess 즉, post 통신이 성공적으로 동작해을 경우 alert 창을 통해 회원가입 성공 여부를 알림.

## 2. 개인정보 수정 (update profile)
### 요구사항
- 사용자 ID와 정보의 수정 사항을 받아 PUT 요청 보내기
- 수정 후에는 자동으로 마이페이지 데이터 새로고침

### Solution
- put 이므로 useMutation 사용!
- 데이터새로고침, 무효화, 쿼리 업데이트 등의 작업을 수행하는 useQueryClient 훅을 통해 마이페이지 데이터 새로고침을 동작하도록 함. 이때, mypage 데이터를 get 할 때 사용했던 query key인 "mypage"를 invalidateQueries 안에 넣어 마이 페이지 데이터 관련 쿼리를 다시 불러옴.

## 3. 마이페이지 조회 (my page fetch)
### 요구 사항
- 사용자 ID를 받아 GET 요청
- 데이터를 30초 유지한 후 다시 요청, 사용자가 마이 페이지를 나간 후에도 5분간 캐시 유지

### Solution
- get이므로 useQuery 사용!
**useQuery:** 서버 상태를 읽어오는 hook이다. 즉, 데이터를 조회하고 캐싱하는 데 사용된다. queryKey 인자를 통해 어떤 데이터에 대한 것인지 식별하며, queryFn을 통해 promise 처리가 이루어지는 함수가 동작하도록 한다. 이외에도 여러 옵션을 설정할 수 있다. (enabled, stateTime 등)
- 데이터를 30초 유지 후, 다시 요청하기 위해 useQuery 안에 staleTime 옵션 사용 (30000)
- mypage를 나간 후에도 5분 간 캐시를 유지하기 위해 useQuery 안에 cacheTime 옵션 사용 (300000)

## 4. 회원 정보 삭제 (delete user)
### 요구 사항
- 사용자 ID를 받아 DELETE 요청
- 삭제 성공 후 삭제 되었다는 알림 띄우기
- 관련된 모든 데이터 무효화
- 삭제 후에도 사용자 정보가 필요할 경우를 대비해 캐시를 관리할 수 있도록 하기

### Solution
- delete 이므로 useMutation 사용!
- onSuccess 옵션을 통해 delete api 요청이 성공적으로 처리되었을 경우 alert 창을 띄워 삭제 사실을 알림.
- 데이터 무효화를 위해 useQueryClient 훅의 invalidateQueries 사용. 이 안에 쿼리 키 "mypage"를 인자로 넣어 관련된 쿼리가 무효화되도록 함.
- 캐시 유지를 위한 옵션인 cacheTime 설정을 통해 관리.


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/a41502ec-e405-4b7c-afa1-359fda21b985)
![image](https://github.com/user-attachments/assets/a87a325d-6cc5-4eb4-98a7-21e5b68cf9bf)
![image](https://github.com/user-attachments/assets/18628d8b-7fd3-4e5b-bbac-a290b5062f0b)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
### 궁금해요!
- 구글링, 챗 gpt를 통해 이리저리 알아보니, enabled나 staleTime, cacheTime과 같은 옵션은 useQuery 옵션이고, useMutation에 쓰더라도 오류가 나는 것은 아니지만 작동되지 않는다는 내용을 봤습니다!! 저희 세션 때는 useMutation 안에 위 언급한 옵션들을 사용했는데, 그래도 작동이 되는 것인지, 아니면 제가 코드 구성을 잘못한 것이 문제인지 궁금합니다!